### PR TITLE
Add .editorconfig with 2-space indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Added .editorconfig file with the following configurations:
- 2 spaces for indentation
- UTF-8 encoding
- Unix-style line endings (LF)
- Insert final newline at end of files
- Trim trailing whitespace (except for Markdown files)